### PR TITLE
User-configurable exported image size

### DIFF
--- a/src/segyviewlib/layoutcanvas.py
+++ b/src/segyviewlib/layoutcanvas.py
@@ -57,8 +57,6 @@ class LayoutCanvas(FigureCanvas):
         self._start_subplot_index = None
         self._keys = Keys()
 
-        self._current_layout = None
-
     def _create_event(self, event):
         data = {
             "x": event.xdata,
@@ -125,12 +123,8 @@ class LayoutCanvas(FigureCanvas):
     def set_plot_layout(self, layout_spec):
         self._figure.set_plot_layout(layout_spec)
         self.layout_changed.emit()
-        self._current_layout = layout_spec
         self.draw()
 
     def layout_figure(self):
         """ :rtype: LayoutFigure """
         return self._figure
-
-    def current_layout(self):
-        return self._current_layout

--- a/src/segyviewlib/layoutcanvas.py
+++ b/src/segyviewlib/layoutcanvas.py
@@ -57,6 +57,8 @@ class LayoutCanvas(FigureCanvas):
         self._start_subplot_index = None
         self._keys = Keys()
 
+        self._current_layout = None
+
     def _create_event(self, event):
         data = {
             "x": event.xdata,
@@ -123,8 +125,12 @@ class LayoutCanvas(FigureCanvas):
     def set_plot_layout(self, layout_spec):
         self._figure.set_plot_layout(layout_spec)
         self.layout_changed.emit()
+        self._current_layout = layout_spec
         self.draw()
 
     def layout_figure(self):
         """ :rtype: LayoutFigure """
         return self._figure
+
+    def current_layout(self):
+        return self._current_layout

--- a/src/segyviewlib/layoutfigure.py
+++ b/src/segyviewlib/layoutfigure.py
@@ -7,6 +7,8 @@ class LayoutFigure(Figure):
     def __init__(self, width=11.7, height=8.3, dpi=100, tight_layout=True, **kwargs):
         super(LayoutFigure, self).__init__(figsize=(width, height), dpi=dpi, tight_layout=tight_layout, **kwargs)
 
+        self._current_layout = None
+
         self._axes = []
         """ :type: list[Axes] """
 
@@ -29,6 +31,8 @@ class LayoutFigure(Figure):
             self.delaxes(self._colormap_axes)
         self._colormap_axes = self.add_subplot(grid_spec[:, columns])
 
+        self._current_layout = layout_spec
+
     def index(self, axes):
         """
         :param axes: The Axes instance to find the index of.
@@ -46,3 +50,6 @@ class LayoutFigure(Figure):
     def layout_axes(self):
         """ :rtype: list[Axes] """
         return list(self._axes)
+
+    def current_layout(self):
+        return self._current_layout

--- a/src/segyviewlib/segyviewwidget.py
+++ b/src/segyviewlib/segyviewwidget.py
@@ -97,7 +97,7 @@ class SegyViewWidget(QWidget):
         else:
             w, h, dpi = image_size
             fig = SliceViewWidget(self._context, width = w, height = h, dpi = dpi)
-            fig.set_plot_layout(self._slice_view_widget.current_layout())
+            fig.set_plot_layout(self._slice_view_widget.layout_figure().current_layout())
 
         fig.layout_figure().savefig(output_file)
 

--- a/src/segyviewlib/segyviewwidget.py
+++ b/src/segyviewlib/segyviewwidget.py
@@ -88,9 +88,18 @@ class SegyViewWidget(QWidget):
 
         output_file = str(output_file).strip()
 
-        if len(output_file) > 0:
-            layout_figure = self._slice_view_widget.layout_figure()
-            layout_figure.savefig(output_file)
+        if len(output_file) == 0:
+            return
+
+        image_size = self._context.image_size
+        if not image_size:
+            fig = self._slice_view_widget
+        else:
+            w, h, dpi = image_size
+            fig = SliceViewWidget(self._context, width = w, height = h, dpi = dpi)
+            fig.set_plot_layout(self._slice_view_widget.current_layout())
+
+        fig.layout_figure().savefig(output_file)
 
     def set_source_filename(self, filename):
         self._slice_data_source.set_source_filename(filename)

--- a/src/segyviewlib/settingswindow.py
+++ b/src/segyviewlib/settingswindow.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import sys
 from PyQt4.QtGui import QCheckBox, QWidget, QFormLayout, QComboBox, QLabel, QSpinBox, QValidator
 from PyQt4.QtGui import QPushButton, QDoubleSpinBox, QHBoxLayout, QVBoxLayout
@@ -141,6 +142,44 @@ class SettingsWindow(QWidget):
         self._interpolation_combo.currentIndexChanged.connect(self._interpolation_changed)
         layout.addRow("Interpolation Type:", self._interpolation_combo)
 
+        self.add_empty_row(layout)
+
+        self._dpi_units  = ["in", "cm", "px"]
+        self._fix_size   = QCheckBox()
+        self._fix_width  = QDoubleSpinBox()
+        self._fix_height = QDoubleSpinBox()
+        self._fix_dpi    = QComboBox()
+
+        if parent is None:
+            w, h, dpi = 11.7, 8.3, 100
+        else:
+            fig = parent._slice_view_widget.layout_figure()
+            w, h = fig.get_size_inches()
+            dpi = fig.dpi
+
+        self._fix_width.setMinimum(1)
+        self._fix_width.setMaximum(32000)
+        self._fix_width.setValue(w)
+
+        self._fix_height.setMinimum(1)
+        self._fix_height.setMaximum(32000)
+        self._fix_height.setValue(h)
+
+        self._fix_width.valueChanged.connect(self._fixed_image)
+        self._fix_height.valueChanged.connect(self._fixed_image)
+
+        self._fix_dpi.addItems(self._dpi_units)
+        self._fix_dpi.activated.connect(self._fixed_image)
+        self._fix_size.toggled.connect(self._fixed_image)
+
+        wxh_layout = QHBoxLayout()
+        wxh_layout.addWidget(self._fix_width)
+        wxh_layout.addWidget(self._fix_height)
+
+        layout.addRow("Fix export size:", self._fix_size)
+        layout.addRow("Width x Height:", wxh_layout)
+        layout.addRow("Unit:", self._fix_dpi)
+
         vertical_layout = QVBoxLayout()
 
         button_layout = QHBoxLayout()
@@ -154,6 +193,30 @@ class SettingsWindow(QWidget):
         vertical_layout.addLayout(button_layout)
 
         self.setLayout(vertical_layout)
+
+    @staticmethod
+    def to_inches(width, height, dpi, scale):
+        if scale == "in":
+            return (width, height, dpi)
+        elif scale == "cm":
+            return (width / 2.54, height / 2.54, dpi)
+        elif scale == "px":
+            return (int(width) / dpi, int(height) / dpi, dpi)
+        else:
+            raise NotImplementedError
+
+    def _fixed_image(self):
+        ctx = self._context
+        if not self._fix_size.isChecked():
+            ctx.set_image_size(None)
+            return
+
+        w = self._fix_width.value()
+        h = self._fix_height.value()
+        dpi = 100
+        scale = self._fix_dpi.currentText()
+
+        ctx.set_image_size(*self.to_inches(w, h, dpi, scale))
 
     def _create_user_value(self):
         layout = QHBoxLayout()

--- a/src/segyviewlib/settingswindow.py
+++ b/src/segyviewlib/settingswindow.py
@@ -148,7 +148,7 @@ class SettingsWindow(QWidget):
         self._fix_size   = QCheckBox()
         self._fix_width  = QDoubleSpinBox()
         self._fix_height = QDoubleSpinBox()
-        self._fix_dpi    = QComboBox()
+        self._fix_dpi_units    = QComboBox()
 
         if parent is None:
             w, h, dpi = 11.7, 8.3, 100
@@ -168,8 +168,8 @@ class SettingsWindow(QWidget):
         self._fix_width.valueChanged.connect(self._fixed_image)
         self._fix_height.valueChanged.connect(self._fixed_image)
 
-        self._fix_dpi.addItems(self._dpi_units)
-        self._fix_dpi.activated.connect(self._fixed_image)
+        self._fix_dpi_units.addItems(self._dpi_units)
+        self._fix_dpi_units.activated.connect(self._fixed_image)
         self._fix_size.toggled.connect(self._fixed_image)
 
         wxh_layout = QHBoxLayout()
@@ -178,7 +178,7 @@ class SettingsWindow(QWidget):
 
         layout.addRow("Fix export size:", self._fix_size)
         layout.addRow("Width x Height:", wxh_layout)
-        layout.addRow("Unit:", self._fix_dpi)
+        layout.addRow("Unit:", self._fix_dpi_units)
 
         vertical_layout = QVBoxLayout()
 
@@ -214,7 +214,7 @@ class SettingsWindow(QWidget):
         w = self._fix_width.value()
         h = self._fix_height.value()
         dpi = 100
-        scale = self._fix_dpi.currentText()
+        scale = self._fix_dpi_units.currentText()
 
         ctx.set_image_size(*self.to_inches(w, h, dpi, scale))
 

--- a/src/segyviewlib/sliceviewcontext.py
+++ b/src/segyviewlib/sliceviewcontext.py
@@ -9,7 +9,7 @@ class SliceViewContext(QObject):
     data_changed = pyqtSignal()
     data_source_changed = pyqtSignal()
 
-    def __init__(self, slice_models, slice_data_source, colormap='seismic', interpolation='nearest'):
+    def __init__(self, slice_models, slice_data_source, colormap='seismic', interpolation='nearest', image_size = None):
         QObject.__init__(self)
 
         self._available_slice_models = slice_models
@@ -27,6 +27,7 @@ class SliceViewContext(QObject):
         self._user_max_value = None
         self._interpolation = interpolation
         self._symmetric_scale = True
+        self._image_size = image_size
 
         self._assign_indexes()
 
@@ -65,6 +66,11 @@ class SliceViewContext(QObject):
         """ :rtype: bool """
         return self._symmetric_scale
 
+    @property
+    def image_size(self):
+        """ :rtype: None | Tuple(float, float, int) """
+        return self._image_size
+
     def set_colormap(self, colormap):
         self._colormap_name = colormap
         self.context_changed.emit()
@@ -93,6 +99,15 @@ class SliceViewContext(QObject):
 
         if dirty:
             self.context_changed.emit()
+
+    def set_image_size(self, width, height = None, dpi = None):
+        if width is None:
+            return
+
+        if height is None or dpi is None:
+            raise ValueError("Internal error: expects width, height, dpi")
+
+        self._image_size = (width, height, dpi)
 
     def create_context(self, assigned_slice_models):
         view_min = None


### PR DESCRIPTION
Allow users to specify width & height of exported images (in inches, cm
or pixels). If this option is not enabled, then the window/figure
geometry will be used.

The figure is rendered to an image by creating a new slice view
instance that reuses the individual views from the on-screen rendered
figure. It therefore inherits current inline, crossline, zoom and layout
as what's rendered on screen - the only proper modifications are w.r.t. geometry.

![segyview-fix-export-scale1](https://cloud.githubusercontent.com/assets/8667957/22459182/e75d9934-e79f-11e6-9468-f61368314423.png)

![segyview-fix-export-scale2](https://cloud.githubusercontent.com/assets/8667957/22459185/e9520c8e-e79f-11e6-894b-8ea630a05125.png)

An exported file, set to 6x3 inches:
![gav-6x3-export](https://cloud.githubusercontent.com/assets/8667957/22458858/a9c17826-e79e-11e6-80be-4e14fe79b562.png)

The same file, but inline+crossline changed:
![gav-6x3-export-il35-xl44](https://cloud.githubusercontent.com/assets/8667957/22458894/c2f4c83e-e79e-11e6-8337-157d25aa1ffd.png)


