### PR TITLE
Custom il/xl header words on startup

### DIFF
--- a/applications/segyviewer.py
+++ b/applications/segyviewer.py
@@ -8,13 +8,17 @@ from segyviewlib import resource_icon, SegyViewWidget
 
 
 class SegyViewer(QMainWindow):
-    def __init__(self, filename=None):
+    def __init__(self, filename=None, il = None, xl = None):
         QMainWindow.__init__(self)
+
+        self.segyioargs = { k: v for k, v in [('iline', il), ('xline', xl)]
+                                          if v is not None }
 
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setWindowTitle("SEG-Y Viewer")
 
-        self._segy_view_widget = SegyViewWidget(filename, show_toolbar=True)
+        self._segy_view_widget = SegyViewWidget(filename, show_toolbar=True,
+                                                          segyioargs = self.segyioargs)
 
         self.setCentralWidget(self._segy_view_widget)
         self.setWindowIcon(resource_icon("350px-SEGYIO.png"))
@@ -34,24 +38,28 @@ class SegyViewer(QMainWindow):
         input_file = str(input_file).strip()
 
         if input_file:
-            self._segy_view_widget.set_source_filename(input_file)
+            self._segy_view_widget.set_source_filename(input_file, **self.segyioargs)
 
 
-def run(filename):
-    segy_viewer = SegyViewer(filename)
+def run(filename, il, xl):
+    segy_viewer = SegyViewer(filename, il, xl)
     segy_viewer.show()
     segy_viewer.raise_()
     sys.exit(q_app.exec_())
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
-        sys.exit("Usage: segyviewer.py [file]")
+    parser = argparse.ArgumentParser(description = 'Simple SEG-Y visualization')
+    parser.add_argument('filename',   type = str, help = 'File to open')
+    parser.add_argument('-i', '--il', type = int,
+                                      help = 'inline identifer')
+    parser.add_argument('-x', '--xl', type = int,
+                                      help = 'crossline identifer')
 
-    filename = sys.argv[1]
+    args = parser.parse_args()
 
     q_app = QApplication(sys.argv)
 
     # import cProfile
     # cProfile.run('run(%s)' % filename, filename=None, sort='cumulative')
-    run(filename)
+    run(args.filename, args.il, args.xl)

--- a/applications/segyviewer.py
+++ b/applications/segyviewer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys
+import argparse
 
 from PyQt4.QtCore import Qt
 from PyQt4.QtGui import QMainWindow, QApplication, QToolButton, QFileDialog, QIcon

--- a/src/segyviewlib/segyviewwidget.py
+++ b/src/segyviewlib/segyviewwidget.py
@@ -5,7 +5,9 @@ from segyviewlib import SliceDataSource, SliceModel, SliceDirection as SD, Slice
 
 
 class SegyViewWidget(QWidget):
-    def __init__(self, filename, show_toolbar=True, color_maps=None, width=11.7, height=8.3, dpi=100, parent=None):
+    def __init__(self, filename, show_toolbar=True, color_maps=None,
+                                 width=11.7, height=8.3, dpi=100,
+                                 segyioargs = {}, parent=None):
         QWidget.__init__(self, parent)
 
         inline = SliceModel("Inline", SD.inline, SD.crossline, SD.depth)
@@ -13,7 +15,7 @@ class SegyViewWidget(QWidget):
         depth = SliceModel("Depth", SD.depth, SD.inline, SD.crossline)
 
         slice_models = [inline, xline, depth]
-        slice_data_source = SliceDataSource(filename)
+        slice_data_source = SliceDataSource(filename, **segyioargs)
         self._slice_data_source = slice_data_source
 
         self._context = SliceViewContext(slice_models, slice_data_source)

--- a/src/segyviewlib/slicedatasource.py
+++ b/src/segyviewlib/slicedatasource.py
@@ -48,12 +48,12 @@ class EmptyDataSource(object):
 class SliceDataSource(QObject):
     slice_data_source_changed = pyqtSignal()
 
-    def __init__(self, filename):
+    def __init__(self, filename, **kwargs):
         QObject.__init__(self)
 
         self._source = None
         """ :type: segyio.SegyFile """
-        self.set_source_filename(filename)
+        self.set_source_filename(filename, **kwargs)
 
     def _close_current_file(self):
         if isinstance(self._source, segyio.SegyFile):
@@ -61,10 +61,10 @@ class SliceDataSource(QObject):
 
         self._source = None
 
-    def set_source_filename(self, filename):
+    def set_source_filename(self, filename, **kwargs):
         if filename:
             try:
-                source = segyio.open(filename, "r")
+                source = segyio.open(filename, "r", **kwargs)
             except:
                 raise
             else:


### PR DESCRIPTION
Pass custom inline or crossline identifier positions on application
startup to the underlying segyio library, instead of assuming all files
are 189/193.

Replaces the sys.argv parsing with a slightly more robust argparse.

```
$ python applications/segyviewer 
usage: segyviewer [-h] [-i IL] [-x XL] filename
segyviewer: error: too few arguments
$ python applications/segyviewer -h
usage: segyviewer [-h] [-i IL] [-x XL] filename

Simple SEG-Y visualization

positional arguments:
  filename        File to open

optional arguments:
  -h, --help      show this help message and exit
  -i IL, --il IL  inline identifer
  -x XL, --xl XL  crossline identifer
$ python applications/segyviewer --help
usage: segyviewer [-h] [-i IL] [-x XL] filename

Simple SEG-Y visualization

positional arguments:
  filename        File to open

optional arguments:
  -h, --help      show this help message and exit
  -i IL, --il IL  inline identifer
  -x XL, --xl XL  crossline identifer
$ python applications/segyviewer -i
usage: segyviewer [-h] [-i IL] [-x XL] filename
segyviewer: error: argument -i/--il: expected one argument
$ python applications/segyviewer -i 189
usage: segyviewer [-h] [-i IL] [-x XL] filename
segyviewer: error: too few arguments
$ python applications/segyviewer -i 189 example.sgy 
$
```