### PR TITLE
Depth/time labels for samples

### DIFF
--- a/src/segyviewlib/settingswindow.py
+++ b/src/segyviewlib/settingswindow.py
@@ -90,14 +90,14 @@ class SettingsWindow(QWidget):
              },
             {"Crossline": [{"set_expanded": True},
                            {"": self._align(self._xl_ctrl.current_index_label)},
-                           {"Inline:": self._align(self._xl_ctrl.index_widget)},
+                           {"Crossline:": self._align(self._xl_ctrl.index_widget)},
                            {"Minimum:": self._align(self._xl_ctrl.min_spinbox, self._xl_ctrl.min_checkbox)},
                            {"Maximum:": self._align(self._xl_ctrl.max_spinbox, self._xl_ctrl.max_checkbox)}
                            ]
              },
             {"Depth": [{"set_expanded": True},
                        {"": self._align(self._depth_ctrl.current_index_label)},
-                       {"Inline:": self._align(self._depth_ctrl.index_widget)},
+                       {"Depth:": self._align(self._depth_ctrl.index_widget)},
                        {"Minimum:": self._align(self._depth_ctrl.min_spinbox, self._depth_ctrl.min_checkbox)},
                        {"Maximum:": self._align(self._depth_ctrl.max_spinbox, self._depth_ctrl.max_checkbox)}
                        ]

--- a/src/segyviewlib/settingswindow.py
+++ b/src/segyviewlib/settingswindow.py
@@ -64,6 +64,10 @@ class SettingsWindow(QWidget):
         self._symmetric_scale = QCheckBox()
         self._symmetric_scale.toggled.connect(self._context.set_symmetric_scale)
 
+        self._samples_unit = QComboBox()
+        self._samples_unit.addItems(['Time (ms)', 'Depth (m)'])
+        self._samples_unit.currentIndexChanged[str].connect(self._context.samples_unit)
+
         # view
         self._view_label = QLabel("")
         self._view_label.setDisabled(True)
@@ -99,7 +103,8 @@ class SettingsWindow(QWidget):
                        {"": self._align(self._depth_ctrl.current_index_label)},
                        {"Depth:": self._align(self._depth_ctrl.index_widget)},
                        {"Minimum:": self._align(self._depth_ctrl.min_spinbox, self._depth_ctrl.min_checkbox)},
-                       {"Maximum:": self._align(self._depth_ctrl.max_spinbox, self._depth_ctrl.max_checkbox)}
+                       {"Maximum:": self._align(self._depth_ctrl.max_spinbox, self._depth_ctrl.max_checkbox)},
+                       {"Type": self._align(self._samples_unit)}
                        ]
              },
             {"Sample": [

--- a/src/segyviewlib/slicedatasource.py
+++ b/src/segyviewlib/slicedatasource.py
@@ -71,6 +71,7 @@ class SliceDataSource(QObject):
                 self._close_current_file()
                 self._source = source
                 self._source.mmap()
+                samples = self._source.samples
         else:
             self._close_current_file()
             self._source = EmptyDataSource()
@@ -99,7 +100,7 @@ class SliceDataSource(QObject):
         elif direction == SliceDirection.crossline:
             return self._source.xlines
         elif direction == SliceDirection.depth:
-            return self._source.samples # add t0?
+            return self._source.samples
         else:
             raise ValueError("Unknown direction: %s" % direction)
 

--- a/src/segyviewlib/sliceview.py
+++ b/src/segyviewlib/sliceview.py
@@ -1,9 +1,8 @@
 from matplotlib import patches
 from matplotlib.ticker import FuncFormatter, AutoLocator
 from matplotlib.image import AxesImage
-from .slicemodel import SliceModel
+from .slicemodel import SliceModel, SliceDirection
 import numpy as np
-
 
 class SliceView(object):
     def __init__(self, axes, model, interpolation="nearest", aspect="auto"):
@@ -82,6 +81,9 @@ class SliceView(object):
         self._image.set_interpolation(context['interpolation'])
         self._update_indicators(context)
         self._set_limits()
+
+        if self._model.index_direction is not SliceDirection.depth:
+            self._image.axes.set_ylabel(context['samples_unit'])
 
     def _update_indicators(self, context):
         """ :type context: dict """

--- a/src/segyviewlib/sliceviewcontext.py
+++ b/src/segyviewlib/sliceviewcontext.py
@@ -65,6 +65,7 @@ class SliceViewContext(QObject):
         self._global_max = None
         self._user_min_value = None
         self._user_max_value = None
+        self._samples_unit = "Time (ms)"
 
         self._view_limits = {}
         for model in self._available_slice_models:
@@ -110,6 +111,10 @@ class SliceViewContext(QObject):
     def symmetric_scale(self):
         """ :rtype: bool """
         return self._symmetric_scale
+
+    def samples_unit(self, val):
+        self._samples_unit = val
+        self.context_changed.emit()
 
     @property
     def image_size(self):
@@ -207,7 +212,8 @@ class SliceViewContext(QObject):
             "min": vmin,
             "max": vmax,
             "interpolation": self.interpolation,
-            "view_limits": self._view_limits
+            "view_limits": self._view_limits,
+            "samples_unit": self._samples_unit,
         }
 
     def _assign_indexes(self):


### PR DESCRIPTION
To more precisly represent what a sample means, the y-axis for inline
and crossline views are augmented with unit information (time/depth).

![timems-depthm1](https://cloud.githubusercontent.com/assets/8667957/24291620/0f589016-108a-11e7-9b0e-985b2fbf688b.png)
![timems-depthm2](https://cloud.githubusercontent.com/assets/8667957/24291621/0f5cb72c-108a-11e7-877d-9d5c29463ab6.png)
![timems-depthm3](https://cloud.githubusercontent.com/assets/8667957/24291622/0f5d4aca-108a-11e7-87a4-aa83702b3598.png)

