### PR TITLE
Support interpreting samples as depth without Qt

### DIFF
--- a/src/segyviewlib/segyviewwidget.py
+++ b/src/segyviewlib/segyviewwidget.py
@@ -106,6 +106,9 @@ class SegyViewWidget(QWidget):
     def set_source_filename(self, filename):
         self._slice_data_source.set_source_filename(filename)
 
+    def as_depth(self):
+        self._context.samples_unit = 'Depth (m)'
+
     def _show_settings(self, toggled):
         self._settings_window.setVisible(toggled)
         if self._settings_window.isMinimized():

--- a/src/segyviewlib/settingswindow.py
+++ b/src/segyviewlib/settingswindow.py
@@ -66,7 +66,7 @@ class SettingsWindow(QWidget):
 
         self._samples_unit = QComboBox()
         self._samples_unit.addItems(['Time (ms)', 'Depth (m)'])
-        self._samples_unit.currentIndexChanged[str].connect(self._context.samples_unit)
+        self._samples_unit.currentIndexChanged[str].connect(self.samples_unit)
 
         # view
         self._view_label = QLabel("")
@@ -182,6 +182,9 @@ class SettingsWindow(QWidget):
         w.setLayout(l)
         return w
 
+    def samples_unit(self, val):
+        self._context.samples_unit = val
+
     def _create_user_value(self):
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -243,6 +246,10 @@ class SettingsWindow(QWidget):
         indexes = ctx.slice_data_source().indexes_for_direction(SliceDirection.depth).tolist()
         index = ctx.index_for_direction(SliceDirection.depth)
         self._depth_ctrl.update_view(indexes, index)
+
+        index = self._samples_unit.findText(ctx.samples_unit)
+        if index != -1:
+            self._samples_unit.setCurrentIndex(index)
 
     def _set_view_label(self, indicator_on):
         self._view_label.setText("indicators {0}".format("on" if indicator_on else "off"))

--- a/src/segyviewlib/sliceviewcontext.py
+++ b/src/segyviewlib/sliceviewcontext.py
@@ -112,6 +112,11 @@ class SliceViewContext(QObject):
         """ :rtype: bool """
         return self._symmetric_scale
 
+    @property
+    def samples_unit(self):
+        return self._samples_unit
+
+    @samples_unit.setter
     def samples_unit(self, val):
         self._samples_unit = val
         self.context_changed.emit()
@@ -213,7 +218,7 @@ class SliceViewContext(QObject):
             "max": vmax,
             "interpolation": self.interpolation,
             "view_limits": self._view_limits,
-            "samples_unit": self._samples_unit,
+            "samples_unit": self.samples_unit,
         }
 
     def _assign_indexes(self):


### PR DESCRIPTION
Support for the case where downstream applications want to consider the
samples in depth instead of time, without having to manually use the
combo box, because some heuristics apply.

Since samples_unit is now read as well as written, they are now
properties rather than get/set methods.