### PR TITLE
Adjust the arrayspinbox validation rule

### DIFF
--- a/src/segyviewlib/arrayspinbox.py
+++ b/src/segyviewlib/arrayspinbox.py
@@ -53,9 +53,8 @@ class ArraySpinBox(QSpinBox):
             index = self._values.index(value)
         except ValueError:
             for value in self._values:
-                if str(value).startswith(text):
+                if str(value).startswith(text[:pos]):
                     return QValidator.Intermediate, pos
-
             return QValidator.Invalid, pos
 
         return QValidator.Acceptable, pos


### PR DESCRIPTION
... for when the input doesn't match the legal values

While the user is editing, only validate the positions up to and including the current editing position. Values after the caret are first validated after editing is completed.