### PR TITLE
Require segyio 1.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-segyio
+segyio >= 1.7.1
 numpy
 matplotlib


### PR DESCRIPTION
https://github.com/Statoil/segyio/pull/307 fixes depth slices having
wrong shape, and will be a part of the 1.7.1 release. Since we rely on
that behaviour for non-square volumes, we need to upgrade the minimum
requirement.

Requires https://github.com/Statoil/segyio/pull/307